### PR TITLE
Adding very basic CLR smoke tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -33,8 +33,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
-      - name: Get LFS files for mujoco conversion testing
-        run: git submodule foreach --recursive 'git lfs pull'
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Docker metadata
@@ -57,7 +55,9 @@ jobs:
           load: true
           cache-from: type=gha,scope=ros-${{ github.event.repository.name }}
           cache-to: type=gha,mode=max,scope=ros-${{ github.event.repository.name }}
-      # Skip packages we don't really care about
+      # Skip packages we don't really care about.
+      # Additionally, functional tests require LFS cloning, so are only run at scheduled times
+      # to save on bandwidth consumption.
       - name: Run tests
         run: |
           docker run --rm \
@@ -67,7 +67,8 @@ jobs:
                 mujoco_ros2_control \
                 mujoco_ros2_control_tests \
                 robotiq_driver \
-                serial &&
+                serial \
+                clr_functional_tests &&
               colcon test-result --verbose
             "
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -33,6 +33,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+      - name: Get LFS files for mujoco conversion testing
+        run: git submodule foreach --recursive 'git lfs pull'
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Docker metadata

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -55,12 +55,17 @@ jobs:
           load: true
           cache-from: type=gha,scope=ros-${{ github.event.repository.name }}
           cache-to: type=gha,mode=max,scope=ros-${{ github.event.repository.name }}
+      # Skip packages we don't really care about
       - name: Run tests
         run: |
           docker run --rm \
             ${{ steps.meta.outputs.tags }} \
             bash -c "
-              colcon test &&
+              colcon test --packages-skip \
+                mujoco_ros2_control \
+                mujoco_ros2_control_tests \
+                robotiq_driver \
+                serial &&
               colcon test-result --verbose
             "
 

--- a/.github/workflows/scheduled_functional_tests.yml
+++ b/.github/workflows/scheduled_functional_tests.yml
@@ -1,0 +1,50 @@
+# Workflow for weekly runs of functional tests on the default branch
+name: functional_tests
+on:
+  schedule:
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-functional
+  cancel-in-progress: true
+
+jobs:
+  functional_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Clone lfs objects required for full functional tests
+        run: git submodule foreach --recursive 'git lfs pull'
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ github.event.repository.name }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+      # TODO: Pull these once they are available
+      - name: Build test image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          target: er4-dev-source
+          push: false
+          load: true
+          cache-from: type=gha,scope=ros-${{ github.event.repository.name }}
+      - name: Run functional tests
+        run: |
+          docker run --rm \
+            ${{ steps.meta.outputs.tags }} \
+            bash -c "
+              colcon test --packages-select clr_functional_tests &&
+              colcon test-result --verbose
+            "

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ log/*
 # pixi environments
 .pixi/*
 !.pixi/config.toml
+
+*.pyc

--- a/pixi.toml
+++ b/pixi.toml
@@ -68,6 +68,7 @@ ros-jazzy-chonkur-description = { path = "./src/chonkur_l_raile/chonkur/chonkur_
 ros-jazzy-chonkur-moveit-config = { path = "./src/chonkur_l_raile/chonkur/chonkur_moveit_config/package.xml" }
 ros-jazzy-clr-deploy = { path = "./src/chonkur_l_raile/clr_deploy/package.xml" }
 ros-jazzy-clr-description = { path = "./src/chonkur_l_raile/clr_description/package.xml" }
+ros-jazzy-clr-functional-tests = { path = "./src/clr_functional_tests/package.xml" }
 ros-jazzy-clr-imetro-environments = { path = "./src/chonkur_l_raile/clr_imetro_environments/package.xml" }
 ros-jazzy-clr-moveit-config = { path = "./src/chonkur_l_raile/clr_moveit_config/package.xml" }
 ros-jazzy-clr-mujoco-config = { path = "./src/chonkur_l_raile/clr_mujoco_config/package.xml" }

--- a/src/clr_functional_tests/CMakeLists.txt
+++ b/src/clr_functional_tests/CMakeLists.txt
@@ -6,15 +6,18 @@ find_package(ament_cmake REQUIRED)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(launch_testing_ament_cmake REQUIRED)
 
   install(
-    DIRECTORY launch
+    DIRECTORY test
     DESTINATION share/${PROJECT_NAME}
   )
 
-  find_package(launch_testing_ament_cmake REQUIRED)
+  add_launch_test(test/clr_kinematic_sim_test.py
+    TIMEOUT 75
+  )
 
-  add_launch_test(test/clr_launch_test.py
+  add_launch_test(test/clr_mujoco_sim_test.py
     TIMEOUT 75
   )
 

--- a/src/clr_functional_tests/CMakeLists.txt
+++ b/src/clr_functional_tests/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(clr_functional_tests)
+
+find_package(ament_cmake REQUIRED)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+
+  install(
+    DIRECTORY launch
+    DESTINATION share/${PROJECT_NAME}
+  )
+
+  find_package(launch_testing_ament_cmake REQUIRED)
+
+  add_launch_test(test/clr_launch_test.py
+    TIMEOUT 75
+  )
+
+endif()
+
+ament_package()

--- a/src/clr_functional_tests/launch/test_launch.py
+++ b/src/clr_functional_tests/launch/test_launch.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2025, United States Government, as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+#
+# All rights reserved.
+#
+# This software is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from launch import LaunchDescription
+from chonkur_deploy.launch_helpers import include_launch_file
+
+
+def generate_launch_description():
+
+    clr_launch = include_launch_file(
+        package_name="clr_deploy",
+        launch_file="control.launch.py",
+        launch_arguments={
+            "use_fake_hardware": "true",
+        }.items(),
+    )
+
+    return LaunchDescription([clr_launch])

--- a/src/clr_functional_tests/package.xml
+++ b/src/clr_functional_tests/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>clr_functional_tests</name>
+  <version>0.0.0</version>
+  <description>Tests for the CLR workspace</description>
+  <maintainer email="erik.holum@nasa.gov">Erik Holum</maintainer>
+
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>clr_deploy</test_depend>
+  <test_depend>clr_mujoco_config</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/clr_functional_tests/test/clr_kinematic_sim_test.py
+++ b/src/clr_functional_tests/test/clr_kinematic_sim_test.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2025, United States Government, as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+#
+# All rights reserved.
+#
+# This software is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import os
+import sys
+import unittest
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_testing.actions import ReadyToTest
+from launch_testing.util import KeepAliveProc
+import pytest
+import rclpy
+from sensor_msgs.msg import JointState
+
+sys.path.append(os.path.dirname(__file__))
+from clr_test import spin_until
+
+
+@pytest.mark.rostest
+def generate_test_description():
+    # This is necessary to get unbuffered output from the process under test
+    proc_env = os.environ.copy()
+    proc_env["PYTHONUNBUFFERED"] = "1"
+
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(get_package_share_directory("clr_deploy"), "launch", "clr_sim.launch.py")
+        ),
+    )
+
+    return LaunchDescription([launch_include, KeepAliveProc(), ReadyToTest()])
+
+
+class TestFixture(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node("test_node")
+        self._latest_js = None
+        self._js_sub = self.node.create_subscription(JointState, "/joint_states", self.joint_state_cb, 10)
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def joint_state_cb(self, msg):
+        self._latest_js = msg
+
+    def test_basic_sim_launch(self):
+        self.assertTrue(
+            spin_until(lambda: self._latest_js is not None, self.node, timeout=10.0),
+            "No joint states received",
+        )
+        expected_joints = {
+            "vention_rail_base_to_carriage",
+            "ewellix_lift_lower_to_higher",
+            "shoulder_pan_joint",
+            "shoulder_lift_joint",
+            "elbow_joint",
+            "wrist_1_joint",
+            "wrist_2_joint",
+            "wrist_3_joint",
+            "finger_1_joint",
+        }
+        self.assertEqual(
+            set(self._latest_js.name),
+            expected_joints,
+            f"Unexpected joints: {self._latest_js.name}",
+        )

--- a/src/clr_functional_tests/test/clr_launch_test.py
+++ b/src/clr_functional_tests/test/clr_launch_test.py
@@ -81,8 +81,24 @@ class TestFixture(unittest.TestCase):
                 return True
         return False
 
-    def test_node_start(self):
+    def test_basic_sim_launch(self):
         self.assertTrue(
             self.spin_until(lambda: self._latest_js is not None, timeout=10.0),
             "No joint states received",
+        )
+        expected_joints = {
+            "vention_rail_base_to_carriage",
+            "ewellix_lift_lower_to_higher",
+            "shoulder_pan_joint",
+            "shoulder_lift_joint",
+            "elbow_joint",
+            "wrist_1_joint",
+            "wrist_2_joint",
+            "wrist_3_joint",
+            "finger_1_joint",
+        }
+        self.assertEqual(
+            set(self._latest_js.name),
+            expected_joints,
+            f"Unexpected joints: {self._latest_js.name}",
         )

--- a/src/clr_functional_tests/test/clr_launch_test.py
+++ b/src/clr_functional_tests/test/clr_launch_test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2025, United States Government, as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+#
+# All rights reserved.
+#
+# This software is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import os
+import time
+import unittest
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_testing.actions import ReadyToTest
+from launch_testing.util import KeepAliveProc
+import pytest
+import rclpy
+from sensor_msgs.msg import JointState
+
+
+@pytest.mark.rostest
+def generate_test_description():
+    # This is necessary to get unbuffered output from the process under test
+    proc_env = os.environ.copy()
+    proc_env["PYTHONUNBUFFERED"] = "1"
+
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(get_package_share_directory("clr_deploy"), "launch", "clr_sim.launch.py")
+        ),
+    )
+
+    return LaunchDescription([launch_include, KeepAliveProc(), ReadyToTest()])
+
+
+class TestFixture(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node("test_node")
+        self._latest_js = None
+        self._latest_actuator_js = None
+        self._js_sub = self.node.create_subscription(JointState, "/joint_states", self.joint_state_cb, 10)
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def joint_state_cb(self, msg):
+        self._latest_js = msg
+
+    def spin_until(self, predicate, timeout=20.0, spin_period=0.05):
+        """Spin the node until predicate() returns True or timeout is reached.
+
+        Returns True if the predicate was satisfied, False on timeout.
+        """
+        end_time = time.time() + timeout
+        while time.time() < end_time:
+            rclpy.spin_once(self.node, timeout_sec=spin_period)
+            if predicate():
+                return True
+        return False
+
+    def test_node_start(self):
+        self.assertTrue(
+            self.spin_until(lambda: self._latest_js is not None, timeout=10.0),
+            "No joint states received",
+        )

--- a/src/clr_functional_tests/test/clr_mujoco_sim_test.py
+++ b/src/clr_functional_tests/test/clr_mujoco_sim_test.py
@@ -18,7 +18,7 @@
 # under the License.
 
 import os
-import time
+import sys
 import unittest
 
 from ament_index_python.packages import get_package_share_directory
@@ -31,6 +31,9 @@ import pytest
 import rclpy
 from sensor_msgs.msg import JointState
 
+sys.path.append(os.path.dirname(__file__))
+from clr_test import spin_until
+
 
 @pytest.mark.rostest
 def generate_test_description():
@@ -40,8 +43,11 @@ def generate_test_description():
 
     launch_include = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            os.path.join(get_package_share_directory("clr_deploy"), "launch", "clr_sim.launch.py")
+            os.path.join(get_package_share_directory("clr_mujoco_config"), "launch", "clr_mujoco.launch.py")
         ),
+        launch_arguments={
+            "headless": "true",
+        }.items(),
     )
 
     return LaunchDescription([launch_include, KeepAliveProc(), ReadyToTest()])
@@ -60,8 +66,11 @@ class TestFixture(unittest.TestCase):
     def setUp(self):
         self.node = rclpy.create_node("test_node")
         self._latest_js = None
-        self._latest_actuator_js = None
+        self._latest_actuator_states = None
         self._js_sub = self.node.create_subscription(JointState, "/joint_states", self.joint_state_cb, 10)
+        self._actuator_sub = self.node.create_subscription(
+            JointState, "/mujoco_actuators_states", self.mujoco_actuator_states_cb, 10
+        )
 
     def tearDown(self):
         self.node.destroy_node()
@@ -69,36 +78,15 @@ class TestFixture(unittest.TestCase):
     def joint_state_cb(self, msg):
         self._latest_js = msg
 
-    def spin_until(self, predicate, timeout=20.0, spin_period=0.05):
-        """Spin the node until predicate() returns True or timeout is reached.
-
-        Returns True if the predicate was satisfied, False on timeout.
-        """
-        end_time = time.time() + timeout
-        while time.time() < end_time:
-            rclpy.spin_once(self.node, timeout_sec=spin_period)
-            if predicate():
-                return True
-        return False
+    def mujoco_actuator_states_cb(self, msg):
+        self._latest_actuator_states = msg
 
     def test_basic_sim_launch(self):
         self.assertTrue(
-            self.spin_until(lambda: self._latest_js is not None, timeout=10.0),
+            spin_until(lambda: self._latest_js is not None, self.node, timeout=30.0),
             "No joint states received",
         )
-        expected_joints = {
-            "vention_rail_base_to_carriage",
-            "ewellix_lift_lower_to_higher",
-            "shoulder_pan_joint",
-            "shoulder_lift_joint",
-            "elbow_joint",
-            "wrist_1_joint",
-            "wrist_2_joint",
-            "wrist_3_joint",
-            "finger_1_joint",
-        }
-        self.assertEqual(
-            set(self._latest_js.name),
-            expected_joints,
-            f"Unexpected joints: {self._latest_js.name}",
+        self.assertTrue(
+            spin_until(lambda: self._latest_actuator_states is not None, self.node, timeout=30.0),
+            "No joint states received",
         )

--- a/src/clr_functional_tests/test/clr_test.py
+++ b/src/clr_functional_tests/test/clr_test.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python3
 #
 # Copyright (c) 2025, United States Government, as represented by the

--- a/src/clr_functional_tests/test/clr_test.py
+++ b/src/clr_functional_tests/test/clr_test.py
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env python3
 #
 # Copyright (c) 2025, United States Government, as represented by the
@@ -17,18 +18,18 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from launch import LaunchDescription
-from chonkur_deploy.launch_helpers import include_launch_file
+import time
+import rclpy
 
 
-def generate_launch_description():
+def spin_until(predicate, node, timeout=20.0, spin_period=0.05):
+    """Spin the node until predicate() returns True or timeout is reached.
 
-    clr_launch = include_launch_file(
-        package_name="clr_deploy",
-        launch_file="control.launch.py",
-        launch_arguments={
-            "use_fake_hardware": "true",
-        }.items(),
-    )
-
-    return LaunchDescription([clr_launch])
+    Returns True if the predicate was satisfied, False on timeout.
+    """
+    end_time = time.time() + timeout
+    while time.time() < end_time:
+        rclpy.spin_once(node, timeout_sec=spin_period)
+        if predicate():
+            return True
+    return False


### PR DESCRIPTION
All these do is launch the kinematic and dynamic sim drivers to make sure they come up. We could do more later but this is a good start for added assurances that stuff hasn't broken...

Due to LFS limitation (as noted below), I have the functional tests in their own job that runs on a schedule to limit our bandwidth consumption. Once we figure out a workaround for that we could have these run on merges to main, or even as part of the normal workflow...