### PR TITLE
Add support for pushing images to DockerHub

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -1,6 +1,6 @@
 # This workflow requires LFS objects, and so should be run less frequently
 # to reduce bandwidth requirements.
-name: functional_tests
+name: build_and_push_images
 on:
   # Run weekly on Monday morning
   schedule:

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -11,6 +11,10 @@ on:
       - '*'
   # Run and push on request
   workflow_dispatch:
+  # TODO: Remove before merging
+  pull_request:
+    branches:
+      - '*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-functional
@@ -36,6 +40,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=tag
+            type=ref,event=pr
       # TODO: Pull these once they are available
       - name: Build test image
         uses: docker/build-push-action@v6

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -1,8 +1,15 @@
-# Workflow for weekly runs of functional tests on the default branch
+# This workflow requires LFS objects, and so should be run less frequently
+# to reduce bandwidth requirements.
 name: functional_tests
 on:
+  # Run weekly on Monday morning
   schedule:
     - cron: '0 8 * * 1'
+  # Always push tagged version
+  push:
+    tags:
+      - '*'
+  # Run and push on request
   workflow_dispatch:
 
 concurrency:
@@ -25,10 +32,10 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ github.event.repository.name }}
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
+            type=ref,event=tag
       # TODO: Pull these once they are available
       - name: Build test image
         uses: docker/build-push-action@v6
@@ -48,3 +55,18 @@ jobs:
               colcon test --packages-select clr_functional_tests &&
               colcon test-result --verbose
             "
+      # Only push if the tests pass
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          target: er4-dev-source
+          push: true
+          cache-from: type=gha,scope=ros-${{ github.event.repository.name }}

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -33,6 +33,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
+          flavor: |
+            latest=false
       # TODO: Pull these once they are available
       - name: Build test image
         uses: docker/build-push-action@v6

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -11,17 +11,13 @@ on:
       - '*'
   # Run and push on request
   workflow_dispatch:
-  # TODO: Remove before merging
-  pull_request:
-    branches:
-      - '*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-functional
   cancel-in-progress: true
 
 jobs:
-  functional_tests:
+  test_and_push:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -37,10 +33,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=tag
-            type=ref,event=pr
       # TODO: Pull these once they are available
       - name: Build test image
         uses: docker/build-push-action@v6

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -39,10 +39,10 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ github.event.repository.name }}
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
+            type=ref,event=tag
       # TODO: Use GHCR or Dockerhub to push images once these are public
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -43,6 +43,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=tag
+            type=ref,event=pr
       # TODO: Use GHCR or Dockerhub to push images once these are public
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -40,6 +40,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
+          flavor: |
+            latest=false
       # TODO: Use GHCR or Dockerhub to push images once these are public
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -102,8 +102,6 @@ jobs:
             ${{ runner.os }}-ccache-main
             ${{ runner.os }}-ccache-
       # Run pixi jobs, and ensure the cache is world readable.
-      # TODO: There is an issue with the colorblob with the newer opencv from conda.
-      #       Need to resolve that before we re-enable tests.
       - name: Build and test in container
         run: |
           docker run --rm \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -40,10 +40,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=tag
-            type=ref,event=pr
       # TODO: Use GHCR or Dockerhub to push images once these are public
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/src/clr_functional_tests/test/clr_kinematic_sim_test.py
+++ b/src/clr_functional_tests/test/clr_kinematic_sim_test.py
@@ -73,7 +73,7 @@ class TestFixture(unittest.TestCase):
 
     def test_basic_sim_launch(self):
         self.assertTrue(
-            spin_until(lambda: self._latest_js is not None, self.node, timeout=10.0),
+            spin_until(lambda: self._latest_js is not None, self.node, timeout=30.0),
             "No joint states received",
         )
         expected_joints = {


### PR DESCRIPTION
At this point we're just setting up the basic infrastructure so that we know it works. Tagged images are available here: https://hub.docker.com/repository/docker/nasajscrobotics/clr_ws/tags

For example, you can pull and run the kinematic simulation with:

```
# Pull the image
docker pull nasajscrobotics/clr_ws:test-0.0.0

# Run the kin sim
docker run -it nasajscrobotics/clr_ws:test-0.0.0 ros2 launch clr_deploy clr_sim.launch.py
```

These are only being pushed weekly and when images are tagged for now... Until we solve the LFS issue.